### PR TITLE
feat: add prefix+A picker for panes with active Claude sessions

### DIFF
--- a/config/.config/ghostty/config
+++ b/config/.config/ghostty/config
@@ -14,6 +14,9 @@ keybind = super+j=text:\x1b\x73
 # CMD+G = lazygit in new tmux window (Ctrl+A -> g)
 keybind = super+g=text:\x01\x67
 
+# CMD+SHIFT+A = show Claude session picker (Ctrl+A -> Shift+A)
+keybind = super+shift+a=text:\x01\x41
+
 # CMD+SHIFT+E = show tmux split with Claude Code
 keybind = super+shift+e=text:\x01\x45
 

--- a/config/.config/ghostty/config
+++ b/config/.config/ghostty/config
@@ -14,8 +14,8 @@ keybind = super+j=text:\x1b\x73
 # CMD+G = lazygit in new tmux window (Ctrl+A -> g)
 keybind = super+g=text:\x01\x67
 
-# CMD+SHIFT+A = show Claude session picker (Ctrl+A -> Shift+A)
-keybind = super+shift+a=text:\x01\x41
+# CMD+SHIFT+N = show Claude session picker (Ctrl+A -> Shift+A)
+keybind = super+shift+n=text:\x01\x41
 
 # CMD+SHIFT+E = show tmux split with Claude Code
 keybind = super+shift+e=text:\x01\x45

--- a/config/bin/claude-pane-map
+++ b/config/bin/claude-pane-map
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Project per-PID Claude state onto live tmux panes.
+#
+# Output (TSV): one line per pane with at least one Claude instance,
+#   <pane_target>\t<status>\t<display_name>\t<cwd>
+#
+# pane_target: "session:window_idx.pane_idx" for tmux switch-client -t
+# display_name: "session_name / window_name"
+# status priority: running > waiting > interrupted > done > stale > none
+set -u
+
+CACHE="${CLAUDE_STATUS_CACHE:-/tmp/claude-status.cache}"
+
+[ ! -s "$CACHE" ] && exit 0
+
+# Priority map (lower = higher priority)
+declare -A PRI=([running]=0 [waiting]=1 [interrupted]=2 [done]=3 [stale]=4 [none]=9)
+
+# Build pid->ppid lookup from a single ps call
+declare -A ppid_of
+while read -r pid ppid; do
+  ppid_of["$pid"]="$ppid"
+done < <(ps -ax -o pid=,ppid= 2>/dev/null | awk '{print $1, $2}')
+
+# Build pane_pid -> target + display from a single tmux call
+declare -A pane_target pane_display
+while IFS=$'\t' read -r pane_pid session win_name win_idx pane_idx; do
+  [ -z "$pane_pid" ] && continue
+  pane_target["$pane_pid"]="${session}:${win_idx}.${pane_idx}"
+  pane_display["$pane_pid"]="${session} / ${win_name}"
+done < <(tmux list-panes -a \
+  -F '#{pane_pid}\t#{session_name}\t#{window_name}\t#{window_index}\t#{pane_index}' \
+  2>/dev/null)
+
+[ ${#pane_target[@]} -eq 0 ] && exit 0
+
+# For each Claude PID in cache, walk ancestry to find its owning pane
+declare -A best_status best_cwd best_pane_pid
+
+while IFS=$'\t' read -r pid _ cwd _ status; do
+  [ -z "$pid" ] && continue
+  [ -z "$status" ] || [ "$status" = "none" ] && continue
+
+  cur="$pid"
+  found_target=""
+  found_pane_pid=""
+  for _ in $(seq 20); do
+    if [ -n "${pane_target[$cur]:-}" ]; then
+      found_target="${pane_target[$cur]}"
+      found_pane_pid="$cur"
+      break
+    fi
+    next="${ppid_of[$cur]:-}"
+    [ -z "$next" ] || [ "$next" = "1" ] || [ "$next" = "$cur" ] && break
+    cur="$next"
+  done
+  [ -z "$found_target" ] && continue
+
+  # Keep highest-priority status for each pane
+  existing="${best_status[$found_target]:-none}"
+  if [ -z "${best_status[$found_target]:-}" ] \
+     || [ "${PRI[$status]:-9}" -lt "${PRI[$existing]:-9}" ]; then
+    best_status["$found_target"]="$status"
+    best_cwd["$found_target"]="$cwd"
+    best_pane_pid["$found_target"]="$found_pane_pid"
+  fi
+done < "$CACHE"
+
+# Emit results sorted by priority (running first)
+for target in "${!best_status[@]}"; do
+  pane_pid="${best_pane_pid[$target]}"
+  printf '%s\t%s\t%s\t%s\n' \
+    "$target" \
+    "${best_status[$target]}" \
+    "${pane_display[$pane_pid]:-$target}" \
+    "${best_cwd[$target]:-}"
+done | sort -t$'\t' -k2,2 -s

--- a/config/bin/claude-pane-map
+++ b/config/bin/claude-pane-map
@@ -1,8 +1,8 @@
-#!/usr/bin/env bash
+#!/usr/bin/env zsh
 # Project per-PID Claude state onto live tmux panes.
 #
 # Output (TSV): one line per pane with at least one Claude instance,
-#   <pane_target>\t<status>\t<display_name>\t<cwd>
+#   <pane_target>\t<status>\t<display_name>\t<cwd>\t<jsonl>
 #
 # pane_target: "session:window_idx.pane_idx" for tmux switch-client -t
 # display_name: "session_name / window_name"
@@ -14,44 +14,45 @@ CACHE="${CLAUDE_STATUS_CACHE:-/tmp/claude-status.cache}"
 [ ! -s "$CACHE" ] && exit 0
 
 # Priority map (lower = higher priority)
-declare -A PRI=([running]=0 [waiting]=1 [interrupted]=2 [done]=3 [stale]=4 [none]=9)
+typeset -A PRI
+PRI=(running 0 waiting 1 interrupted 2 done 3 stale 4 none 9)
 
 # Build pid->ppid lookup from a single ps call
-declare -A ppid_of
+typeset -A ppid_of
 while read -r pid ppid; do
-  ppid_of["$pid"]="$ppid"
+  ppid_of[$pid]=$ppid
 done < <(ps -ax -o pid=,ppid= 2>/dev/null | awk '{print $1, $2}')
 
 # Build pane_pid -> target + display from a single tmux call
-declare -A pane_target pane_display
+typeset -A pane_target pane_display
 while IFS=$'\t' read -r pane_pid session win_name win_idx pane_idx; do
   [ -z "$pane_pid" ] && continue
-  pane_target["$pane_pid"]="${session}:${win_idx}.${pane_idx}"
-  pane_display["$pane_pid"]="${session} / ${win_name}"
+  pane_target[$pane_pid]="${session}:${win_idx}.${pane_idx}"
+  pane_display[$pane_pid]="${session} / ${win_name}"
 done < <(tmux list-panes -a \
-  -F '#{pane_pid}\t#{session_name}\t#{window_name}\t#{window_index}\t#{pane_index}' \
+  -F $'#{pane_pid}\t#{session_name}\t#{window_name}\t#{window_index}\t#{pane_index}' \
   2>/dev/null)
 
-[ ${#pane_target[@]} -eq 0 ] && exit 0
+[ ${#pane_target} -eq 0 ] && exit 0
 
 # For each Claude PID in cache, walk ancestry to find its owning pane
-declare -A best_status best_cwd best_pane_pid
+typeset -A best_status best_cwd best_pane_pid best_jsonl
 
-while IFS=$'\t' read -r pid _ cwd _ status; do
+while IFS=$'\t' read -r pid _ cwd jsonl st; do
   [ -z "$pid" ] && continue
-  [ -z "$status" ] || [ "$status" = "none" ] && continue
+  [ -z "$st" ] && continue
 
   cur="$pid"
   found_target=""
   found_pane_pid=""
-  for _ in $(seq 20); do
+  for _ in {1..20}; do
     if [ -n "${pane_target[$cur]:-}" ]; then
       found_target="${pane_target[$cur]}"
       found_pane_pid="$cur"
       break
     fi
     next="${ppid_of[$cur]:-}"
-    [ -z "$next" ] || [ "$next" = "1" ] || [ "$next" = "$cur" ] && break
+    { [ -z "$next" ] || [ "$next" = "1" ] || [ "$next" = "$cur" ]; } && break
     cur="$next"
   done
   [ -z "$found_target" ] && continue
@@ -59,19 +60,21 @@ while IFS=$'\t' read -r pid _ cwd _ status; do
   # Keep highest-priority status for each pane
   existing="${best_status[$found_target]:-none}"
   if [ -z "${best_status[$found_target]:-}" ] \
-     || [ "${PRI[$status]:-9}" -lt "${PRI[$existing]:-9}" ]; then
-    best_status["$found_target"]="$status"
-    best_cwd["$found_target"]="$cwd"
-    best_pane_pid["$found_target"]="$found_pane_pid"
+     || [ "${PRI[$st]:-9}" -lt "${PRI[$existing]:-9}" ]; then
+    best_status[$found_target]=$st
+    best_cwd[$found_target]=$cwd
+    best_pane_pid[$found_target]=$found_pane_pid
+    best_jsonl[$found_target]=$jsonl
   fi
 done < "$CACHE"
 
 # Emit results sorted by priority (running first)
-for target in "${!best_status[@]}"; do
+for target in ${(k)best_status}; do
   pane_pid="${best_pane_pid[$target]}"
-  printf '%s\t%s\t%s\t%s\n' \
+  printf '%s\t%s\t%s\t%s\t%s\n' \
     "$target" \
     "${best_status[$target]}" \
     "${pane_display[$pane_pid]:-$target}" \
-    "${best_cwd[$target]:-}"
+    "${best_cwd[$target]:-}" \
+    "${best_jsonl[$target]:-}"
 done | sort -t$'\t' -k2,2 -s

--- a/config/bin/claude-pick
+++ b/config/bin/claude-pick
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Picker for tmux panes/windows with active Claude sessions.
+# Each row shows status glyph + session/window name + cwd.
+# Selecting a row switches the tmux client to that pane.
+#
+# Bound to prefix+C in .tmux.conf.
+set -u
+
+glyph() {
+  case $1 in
+    running)     printf '●' ;;
+    waiting)     printf '◐' ;;
+    interrupted) printf '⚠' ;;
+    done)        printf '✓' ;;
+    stale)       printf '✗' ;;
+    *)           printf ' ' ;;
+  esac
+}
+
+rows=$(
+  claude-pane-map | while IFS=$'\t' read -r target status name cwd; do
+    g=$(glyph "$status")
+    short="${cwd/#$HOME/\~}"
+    printf '%s\t%s  %-36s  %s\n' "$target" "$g" "$name" "$short"
+  done
+)
+
+if [ -z "$rows" ]; then
+  tmux display-message "No active Claude sessions"
+  exit 0
+fi
+
+selection=$(
+  printf '%s\n' "$rows" \
+  | fzf-tmux -p 80%,50% \
+      --no-border \
+      --ansi \
+      --list-border \
+      --delimiter $'\t' \
+      --with-nth 2 \
+      --prompt '  ' \
+      --no-sort \
+      --bind 'tab:down,btab:up' \
+      --bind 'ctrl-b:abort' \
+      --color 'list-border:6,input-border:3,preview-border:4,current-bg:254,current-fg:-1,current-hl:5'
+) || true
+
+[ -z "${selection:-}" ] && exit 0
+
+target=$(printf '%s' "$selection" | cut -f1)
+tmux switch-client -t "$target"

--- a/config/bin/claude-pick
+++ b/config/bin/claude-pick
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Picker for tmux panes/windows with active Claude sessions.
-# Each row shows status glyph + session/window name + cwd.
+# Row: <glyph> <task>  <project>  <branch-tip>
+# Right pane previews live tmux pane contents.
 # Selecting a row switches the tmux client to that pane.
 #
 # Bound to prefix+C in .tmux.conf.
@@ -17,11 +18,42 @@ glyph() {
   esac
 }
 
+# Pull a short task label from a Claude jsonl.
+# Order: explicit summary record → first non-command user prompt.
+task_label() {
+  local f=$1 s
+  [ -s "$f" ] || { printf ''; return; }
+  s=$(jq -r 'select(.type=="summary") | .summary' "$f" 2>/dev/null | head -n 1)
+  if [ -z "$s" ]; then
+    s=$(
+      jq -r '
+        select(.type=="user" and (.message.role=="user"))
+        | .message.content
+        | if type=="string" then . else (.[] | select(.type=="text") | .text) end
+      ' "$f" 2>/dev/null \
+      | grep -vE '^[[:space:]]*(<|\[|$)' \
+      | head -n 1
+    )
+  fi
+  s=${s//$'\n'/ }
+  printf '%s' "${s:0:75}"
+}
+
+branch_tip() {
+  local b
+  b=$(git -C "$1" rev-parse --abbrev-ref HEAD 2>/dev/null) || return
+  printf '%s' "${b##*/}"
+}
+
 rows=$(
-  claude-pane-map | while IFS=$'\t' read -r target status name cwd; do
+  claude-pane-map | while IFS=$'\t' read -r target status name cwd jsonl; do
     g=$(glyph "$status")
-    short="${cwd/#$HOME/\~}"
-    printf '%s\t%s  %-36s  %s\n' "$target" "$g" "$name" "$short"
+    proj=$(basename "$cwd")
+    br=$(branch_tip "$cwd")
+    task=$(task_label "$jsonl")
+    [ -z "$task" ] && task='—'
+    label=$(printf '%s  %-75s  %-18s  %s' "$g" "$task" "$proj" "$br")
+    printf '%s\t%s\n' "$target" "$label"
   done
 )
 
@@ -32,7 +64,7 @@ fi
 
 selection=$(
   printf '%s\n' "$rows" \
-  | fzf-tmux -p 80%,50% \
+  | fzf-tmux -p 90%,80% \
       --no-border \
       --ansi \
       --list-border \
@@ -42,6 +74,8 @@ selection=$(
       --no-sort \
       --bind 'tab:down,btab:up' \
       --bind 'ctrl-b:abort' \
+      --preview-window 'right:55%' \
+      --preview 'tmux capture-pane -ep -t {1}' \
       --color 'list-border:6,input-border:3,preview-border:4,current-bg:254,current-fg:-1,current-hl:5'
 ) || true
 

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -79,6 +79,9 @@ bind-key "R" run-shell "~/.dotfiles/config/bin/sesh-pick root"
 # show lazygit pop up window (in current pane's cwd, not session start dir)
 bind -N "lazygit" g display-popup -w 90% -h 90% -d "#{pane_current_path}" -E "lazygit 2> /dev/null"
 
+# claude session picker — panes/windows with active Claude chats
+bind-key "C" run-shell "~/.dotfiles/config/bin/claude-pick"
+
 # add claude code split
 bind-key "E" split-window -h "claude"
 

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -80,7 +80,7 @@ bind-key "R" run-shell "~/.dotfiles/config/bin/sesh-pick root"
 bind -N "lazygit" g display-popup -w 90% -h 90% -d "#{pane_current_path}" -E "lazygit 2> /dev/null"
 
 # claude session picker — panes/windows with active Claude chats
-bind-key "C" run-shell "~/.dotfiles/config/bin/claude-pick"
+bind-key "A" run-shell "~/.dotfiles/config/bin/claude-pick"
 
 # add claude code split
 bind-key "E" split-window -h "claude"


### PR DESCRIPTION
New claude-pick script opens an fzf-tmux popup listing only the panes
and windows that currently have a Claude process running in them, each
decorated with the same status glyphs used in the sesh picker (●◐⚠✓✗).
Selecting a row switches the tmux client directly to that pane.

New claude-pane-map script is the data layer: reads the existing
/tmp/claude-status.cache, builds a pid->ppid tree from one ps call,
and walks process ancestry for each Claude PID to find its owning tmux
pane — more reliable than cwd matching since pane_current_path changes
as the user navigates but Claude's cwd stays fixed.

https://claude.ai/code/session_0146m5YGSYJChpMQeNRMASvd